### PR TITLE
Fix unused import warnings in Rust codebase

### DIFF
--- a/src/intelligence/performance.rs
+++ b/src/intelligence/performance.rs
@@ -5,6 +5,7 @@
 
 use std::alloc::{alloc, dealloc, Layout};
 use std::collections::VecDeque;
+use std::process::Command;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -490,7 +491,6 @@ impl PerformanceMonitor {
     /// Get CPU utilization (simplified implementation)
     fn get_cpu_utilization() -> f64 {
         // Get CPU utilization using system commands
-        use std::process::Command;
         
         // Use system-specific commands to get CPU usage
         #[cfg(target_os = "macos")]
@@ -548,7 +548,6 @@ impl PerformanceMonitor {
     /// Get memory usage in bytes
     fn get_memory_usage() -> usize {
         // Get memory usage using system-specific methods
-        use std::process::Command;
         
         #[cfg(target_os = "macos")]
         {

--- a/src/intelligence/service_detection.rs
+++ b/src/intelligence/service_detection.rs
@@ -11,9 +11,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-use openssl::x509::X509;
 use regex::Regex;
-use lazy_static::lazy_static;
 
 use super::core::IntelligenceResult;
 use super::performance::{UltraFastThreadPool, MemoryPool};

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,12 +6,11 @@ use crate::network::{PortState, Protocol};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{self, Write};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tokio::sync::{broadcast, RwLock};
+use std::time::Duration;
+use tokio::sync::broadcast;
 use chrono::{DateTime, Utc};
 use quick_xml::Writer;
-use quick_xml::events::{Event, BytesEnd, BytesStart, BytesText};
+use quick_xml::events::{Event, BytesEnd, BytesStart};
 use std::io::Cursor;
 
 /// Output format options


### PR DESCRIPTION
This PR fixes all unused import warnings that were appearing during the build process:\n\n- Removed unused imports from service_detection.rs (openssl::x509::X509, lazy_static::lazy_static)\n- Fixed std::process::Command import in performance.rs by moving it to top level\n- Removed unused imports from output/mod.rs (std::sync::Arc, Instant, RwLock, BytesText)\n\nAll changes maintain functionality while cleaning up the codebase and eliminating build warnings.